### PR TITLE
Add login and signup modals

### DIFF
--- a/src/views/components/AppHeader.vue
+++ b/src/views/components/AppHeader.vue
@@ -1,12 +1,39 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref } from "vue";
+
+import LoginModal from "./LoginModal.vue";
+import RegisterModal from "./RegisterModal.vue";
+
+const showLogin = ref(false);
+const showRegister = ref(false);
+</script>
 
 <template>
-  <v-app-bar
-    flat
-    class="px-4 bg-gray-200"
-  >
-    <span class="font-bold">MDS App</span>
+  <v-app-bar flat class="px-4 bg-gray-200">
+    <img
+      src="@/assets/logo.png"
+      alt="Logo"
+      class="h-8 mr-4"
+    />
+    <v-spacer />
+    <v-btn
+      variant="text"
+      class="mr-2"
+      @click="showLogin = true"
+    >
+      Connexion
+    </v-btn>
+    <v-btn color="primary" @click="showRegister = true">Inscription</v-btn>
   </v-app-bar>
+
+  <LoginModal
+    v-model="showLogin"
+    @switch="() => { showLogin = false; showRegister = true; }"
+  />
+  <RegisterModal
+    v-model="showRegister"
+    @switch="() => { showRegister = false; showLogin = true; }"
+  />
 </template>
 
 <style scoped></style>

--- a/src/views/components/LoginModal.vue
+++ b/src/views/components/LoginModal.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+const props = defineProps<{ modelValue: boolean }>();
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+  (e: "switch"): void;
+}>();
+
+const dialog = computed({
+  get: () => props.modelValue,
+  set: (v: boolean) => emit("update:modelValue", v),
+});
+
+const showPassword = ref(false);
+</script>
+
+<template>
+  <v-dialog v-model="dialog" width="400">
+    <v-card>
+      <v-card-title class="text-lg font-bold">Connexion</v-card-title>
+      <v-card-text>
+        <v-text-field label="Email" type="email" class="mb-2" />
+        <v-text-field
+          :type="showPassword ? 'text' : 'password'"
+          label="Mot de passe"
+          :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+          @click:append-inner="showPassword = !showPassword"
+          class="mb-2"
+        />
+        <div class="text-right">
+          <v-btn variant="text" size="small">Mot de passe oublié ?</v-btn>
+        </div>
+      </v-card-text>
+      <v-card-actions class="justify-between">
+        <v-spacer />
+        <v-btn color="primary">Se connecter</v-btn>
+      </v-card-actions>
+      <v-card-actions class="justify-end pt-0">
+        <v-btn variant="text" @click="emit('switch')">
+          Je n'ai pas encore de compte
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped></style>

--- a/src/views/components/RegisterModal.vue
+++ b/src/views/components/RegisterModal.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+const props = defineProps<{ modelValue: boolean }>();
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+  (e: "switch"): void;
+}>();
+
+const dialog = computed({
+  get: () => props.modelValue,
+  set: (v: boolean) => emit("update:modelValue", v),
+});
+
+const showPassword = ref(false);
+</script>
+
+<template>
+  <v-dialog v-model="dialog" width="400">
+    <v-card>
+      <v-card-title class="text-lg font-bold">Inscription</v-card-title>
+      <v-card-text>
+        <v-text-field label="Email" type="email" class="mb-2" />
+        <v-text-field label="Nom" class="mb-2" />
+        <v-text-field
+          :type="showPassword ? 'text' : 'password'"
+          label="Mot de passe"
+          :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+          @click:append-inner="showPassword = !showPassword"
+          class="mb-2"
+        />
+      </v-card-text>
+      <v-card-actions class="justify-between">
+        <v-spacer />
+        <v-btn color="primary">S'inscrire</v-btn>
+      </v-card-actions>
+      <v-card-actions class="justify-end pt-0">
+        <v-btn variant="text" @click="emit('switch')">
+          J'ai déjà un compte
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- update AppHeader with logo, login and signup buttons
- add LoginModal and RegisterModal components with toggle

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684042ce6b448328b3e48c9387323dc7