### PR TITLE
Handle JWT cookie auth

### DIFF
--- a/src/features/users/useLogin.ts
+++ b/src/features/users/useLogin.ts
@@ -17,9 +17,10 @@ export function useLogin() {
     error.value = null;
     const response = await fetcherHelper<{ token: string }>({
       apiUrl: VITE_API_URL as string,
-      endPoint: ApiEndpointEnum.USER_REGISTER,
+      endPoint: ApiEndpointEnum.USER_LOGIN,
       method: FetchMethodsEnum.POST,
       body: { email, password },
+      withAuth: false,
     });
     loading.value = false;
     if (response.success && response.data) {

--- a/src/features/users/useRegister.ts
+++ b/src/features/users/useRegister.ts
@@ -28,10 +28,11 @@ export function useRegister() {
       endPoint: ApiEndpointEnum.USER_REGISTER,
       method: FetchMethodsEnum.POST,
       body: args,
+      withAuth: false,
     });
     loading.value = false;
     if (response.success && response.data) {
-      setCookie({ name: "token", value: MET LE CODE ICI, hours: 1 });
+      setCookie({ name: "token", value: response.data.token, hours: 1 });
       return true;
     }
     error.value = response.status;

--- a/src/helpers/api/fetcher.helper.ts
+++ b/src/helpers/api/fetcher.helper.ts
@@ -1,11 +1,14 @@
 import { FetchMethodsEnum } from "../../enums/fetchMethods.enum";
 import type { FetchResponse } from "../data/fetchResponse.type";
 
+import { getAuthHeader } from "./getAuthHeader.helper";
+
 type Args = {
   apiUrl: string;
   endPoint: string;
   method: FetchMethodsEnum;
   body?: unknown;
+  withAuth?: boolean;
 };
 
 export const fetcherHelper = async <T>({
@@ -13,11 +16,13 @@ export const fetcherHelper = async <T>({
   endPoint,
   method,
   body,
+  withAuth = true,
 }: Args): Promise<FetchResponse<T>> => {
   try {
     const response = await fetch(`${apiUrl}${endPoint}`, {
       headers: {
         Accept: "application/json",
+        ...(withAuth ? getAuthHeader() : {}),
         ...(method !== FetchMethodsEnum.GET && {
           "Content-Type": "application/json",
         }),

--- a/src/helpers/api/getAuthHeader.helper.ts
+++ b/src/helpers/api/getAuthHeader.helper.ts
@@ -1,0 +1,9 @@
+import { getCookie } from "../cookie/getCookie.helper";
+
+export const getAuthHeader = (): Record<string, string> => {
+  const token = getCookie("token");
+  if (token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return {};
+};


### PR DESCRIPTION
## Summary
- keep JWT token in cookie
- send auth cookie via Authorization header
- let fetcher opt out of auth header

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `pnpm unit-test-once` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841654f68248328a3454d0e5f69d02a