### PR TITLE
Add profile update forms

### DIFF
--- a/src/enums/apiEndpoint.enum.ts
+++ b/src/enums/apiEndpoint.enum.ts
@@ -1,4 +1,6 @@
 export enum ApiEndpointEnum {
   USER_REGISTER = "/v1/users/register",
   USER_LOGIN = "/v1/users/login",
+  USER_PASSWORD = "/v1/users/password",
+  USER_MAIL = "/v1/users/mail",
 }

--- a/src/enums/fetchMethods.enum.ts
+++ b/src/enums/fetchMethods.enum.ts
@@ -2,6 +2,7 @@ export enum FetchMethodsEnum {
   GET = "GET",
   HEAD = "HEAD",
   POST = "POST",
+  PUT = "PUT",
   DELETE = "DELETE",
   CONNECT = "CONNECT",
   OPTIONS = "OPTIONS",

--- a/src/features/users/useUpdateMail.ts
+++ b/src/features/users/useUpdateMail.ts
@@ -1,0 +1,38 @@
+import { ref } from "vue";
+
+import { FetchMethodsEnum } from "@/enums/fetchMethods.enum";
+import { fetcherHelper } from "@/helpers/api/fetcher.helper";
+import { setCookie } from "@/helpers/cookie/setCookie.helper";
+
+import { ApiEndpointEnum } from "@/enums/apiEndpoint.enum";
+import { CookieEnum } from "@/enums/cookie.enum";
+import { useUserStore } from "@/stores/user";
+
+const { VITE_API_URL } = import.meta.env;
+
+export function useUpdateMail() {
+  const storeUser = useUserStore();
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  const updateMail = async ({ email }: { email: string }) => {
+    loading.value = true;
+    error.value = null;
+    const response = await fetcherHelper<{ email: string }>({
+      apiUrl: VITE_API_URL as string,
+      endPoint: ApiEndpointEnum.USER_MAIL,
+      method: FetchMethodsEnum.PUT,
+      body: { email },
+    });
+    loading.value = false;
+    if (response.success && response.data) {
+      setCookie({ name: CookieEnum.EMAIL, value: response.data.email, hours: 12 });
+      storeUser.updateEmail(response.data.email);
+      return true;
+    }
+    error.value = response.status;
+    return false;
+  };
+
+  return { updateMail, loading, error };
+}

--- a/src/features/users/useUpdatePassword.ts
+++ b/src/features/users/useUpdatePassword.ts
@@ -1,0 +1,41 @@
+import { ref } from "vue";
+
+import { FetchMethodsEnum } from "@/enums/fetchMethods.enum";
+import { fetcherHelper } from "@/helpers/api/fetcher.helper";
+import { ApiEndpointEnum } from "@/enums/apiEndpoint.enum";
+
+const { VITE_API_URL } = import.meta.env;
+
+export function useUpdatePassword() {
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  const updatePassword = async ({
+    oldPassword,
+    newPassword,
+    confirmationPassword,
+  }: {
+    oldPassword: string;
+    newPassword: string;
+    confirmationPassword: string;
+  }) => {
+    loading.value = true;
+    error.value = null;
+    const response = await fetcherHelper<unknown>({
+      apiUrl: VITE_API_URL as string,
+      endPoint: ApiEndpointEnum.USER_PASSWORD,
+      method: FetchMethodsEnum.PUT,
+      body: {
+        oldPassword,
+        newPassword,
+        confirmationPassword,
+      },
+    });
+    loading.value = false;
+    if (response.success) return true;
+    error.value = response.status;
+    return false;
+  };
+
+  return { updatePassword, loading, error };
+}

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -29,5 +29,8 @@ export const useUserStore = defineStore("user", {
       deleteCookie(CookieEnum.FULLNAME);
       deleteCookie(CookieEnum.EMAIL);
     },
+    updateEmail(email: string) {
+      this.email = email;
+    },
   },
 });

--- a/src/views/pages/profile/ProfilePage.vue
+++ b/src/views/pages/profile/ProfilePage.vue
@@ -1,15 +1,91 @@
 <script setup lang="ts">
+import { ref } from "vue";
+
 import AppHeader from "../../components/AppHeader.vue";
 import AuthGard from "../../components/AuthGard.vue";
+import { useUpdateMail } from "@/features/users/useUpdateMail";
+import { useUpdatePassword } from "@/features/users/useUpdatePassword";
+
+const newEmail = ref("");
+const oldPassword = ref("");
+const newPassword = ref("");
+const confirmPassword = ref("");
+
+const { updateMail } = useUpdateMail();
+const { updatePassword } = useUpdatePassword();
+
+async function handleUpdateMail() {
+  try {
+    await updateMail({ email: newEmail.value });
+    newEmail.value = "";
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function handleUpdatePassword() {
+  try {
+    await updatePassword({
+      oldPassword: oldPassword.value,
+      newPassword: newPassword.value,
+      confirmationPassword: confirmPassword.value,
+    });
+    oldPassword.value = "";
+    newPassword.value = "";
+    confirmPassword.value = "";
+  } catch (error) {
+    console.error(error);
+  }
+}
 </script>
 
 <template>
   <AuthGard>
     <div>
       <AppHeader />
-      <main class="p-4">
-        <h1 class="text-xl font-bold">Product page</h1>
-        <p>Voici un super produit.</p>
+      <main class="p-4 space-y-8">
+        <section>
+          <h1 class="text-xl font-bold mb-4">Modifier mon adresse email</h1>
+          <input
+            v-model="newEmail"
+            type="email"
+            placeholder="Nouvelle adresse email"
+            class="mb-2 w-full border p-2 rounded"
+          />
+          <button
+            class="bg-blue-600 text-white px-3 py-1 rounded"
+            @click="handleUpdateMail"
+          >
+            Confirmer
+          </button>
+        </section>
+        <section>
+          <h1 class="text-xl font-bold mb-4">Modifier mon mot de passe</h1>
+          <input
+            v-model="oldPassword"
+            type="password"
+            placeholder="Ancien mot de passe"
+            class="mb-2 w-full border p-2 rounded"
+          />
+          <input
+            v-model="newPassword"
+            type="password"
+            placeholder="Nouveau mot de passe"
+            class="mb-2 w-full border p-2 rounded"
+          />
+          <input
+            v-model="confirmPassword"
+            type="password"
+            placeholder="Confirmation du nouveau mot de passe"
+            class="mb-2 w-full border p-2 rounded"
+          />
+          <button
+            class="bg-blue-600 text-white px-3 py-1 rounded"
+            @click="handleUpdatePassword"
+          >
+            Confirmer
+          </button>
+        </section>
       </main>
     </div>
   </AuthGard>


### PR DESCRIPTION
## Summary
- allow API calls to update user mail and password
- support PUT method and add user endpoints
- expose store action to update email
- add profile page forms for updating mail and password

## Testing
- `pnpm lint-fix` *(fails: ESLint couldn't find config)*
- `pnpm exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423f110dec8328bf0e1de4f5139007