### PR TITLE
Add unit tests for helpers and store

### DIFF
--- a/src/helpers/api/fetcher.helper.test.ts
+++ b/src/helpers/api/fetcher.helper.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetcherHelper } from './fetcher.helper';
+import { FetchMethodsEnum } from '@/enums/fetchMethods.enum';
+
+const apiUrl = 'https://api.example.com';
+const endPoint = '/endpoint';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetcherHelper', () => {
+  it('returns data when request is successful', async () => {
+    const data = { hello: 'world' };
+    const headers = new Headers();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(data),
+      headers,
+    }));
+
+    const result = await fetcherHelper<typeof data>({
+      apiUrl,
+      endPoint,
+      method: FetchMethodsEnum.GET,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      status: '200 - OK',
+      headers,
+      data,
+    });
+  });
+
+  it("returns special message when status is 404", async () => {
+    const headers = new Headers();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      headers,
+      json: vi.fn(),
+    }));
+
+    const result = await fetcherHelper({
+      apiUrl,
+      endPoint,
+      method: FetchMethodsEnum.GET,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      status: "Save don't able this request",
+      headers,
+    });
+  });
+
+  it('handles fetch rejection', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fail')));
+
+    const result = await fetcherHelper({
+      apiUrl,
+      endPoint,
+      method: FetchMethodsEnum.GET,
+    });
+
+    expect(result).toEqual({ success: false, status: 'Request failed' });
+  });
+});

--- a/src/helpers/api/getAuthHeader.helper.test.ts
+++ b/src/helpers/api/getAuthHeader.helper.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getAuthHeader } from './getAuthHeader.helper';
+import { CookieEnum } from '@/enums/cookie.enum';
+import { setCookie } from '../cookie/setCookie.helper';
+import { deleteCookie } from '../cookie/deleteCookie.helper';
+
+beforeEach(() => {
+  document.cookie = '';
+});
+
+describe('getAuthHeader', () => {
+  it('returns Authorization header when token cookie is present', () => {
+    setCookie({ name: CookieEnum.TOKEN, value: 'token-value', hours: 1 });
+    expect(getAuthHeader()).toEqual({ Authorization: 'token-value' });
+  });
+
+  it('returns empty object when token cookie is missing', () => {
+    deleteCookie(CookieEnum.TOKEN);
+    expect(getAuthHeader()).toEqual({});
+  });
+});

--- a/src/helpers/cookie/cookie.helpers.test.ts
+++ b/src/helpers/cookie/cookie.helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setCookie } from './setCookie.helper';
+import { getCookie } from './getCookie.helper';
+import { checkCookie } from './checkCookie.helper';
+import { deleteCookie } from './deleteCookie.helper';
+
+const COOKIE_NAME = 'test_cookie';
+
+// jsdom shares document between tests so reset before each test
+beforeEach(() => {
+  document.cookie = '';
+});
+
+describe('cookie helpers', () => {
+  it('setCookie and getCookie work together', () => {
+    setCookie({ name: COOKIE_NAME, value: 'value', hours: 1 });
+    expect(getCookie(COOKIE_NAME)).toBe('value');
+  });
+
+  it('checkCookie returns true if cookie exists', () => {
+    setCookie({ name: COOKIE_NAME, value: 'value', hours: 1 });
+    expect(checkCookie(COOKIE_NAME)).toBe(true);
+  });
+
+  it('checkCookie returns false if cookie does not exist', () => {
+    expect(checkCookie(COOKIE_NAME)).toBe(false);
+  });
+
+  it('deleteCookie removes cookie', () => {
+    setCookie({ name: COOKIE_NAME, value: 'value', hours: 1 });
+    deleteCookie(COOKIE_NAME);
+    expect(getCookie(COOKIE_NAME)).toBeUndefined();
+  });
+});

--- a/src/helpers/data/getIsNotNullorUndefined.helper.test.ts
+++ b/src/helpers/data/getIsNotNullorUndefined.helper.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { getIsNotNullorUndefined } from './getIsNotNullorUndefined.helper';
+
+describe('getIsNotNullorUndefined', () => {
+  it('returns true for values that are not null or undefined', () => {
+    expect(getIsNotNullorUndefined(0)).toBe(true);
+    expect(getIsNotNullorUndefined('')).toBe(true);
+    expect(getIsNotNullorUndefined(false)).toBe(true);
+  });
+
+  it('returns false for null or undefined', () => {
+    expect(getIsNotNullorUndefined(null)).toBe(false);
+    expect(getIsNotNullorUndefined(undefined)).toBe(false);
+  });
+});

--- a/src/stores/user.test.ts
+++ b/src/stores/user.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useUserStore } from './user';
+
+vi.mock('../helpers/cookie/getCookie.helper', () => ({
+  getCookie: vi.fn(() => undefined),
+}));
+vi.mock('../helpers/cookie/deleteCookie.helper', () => ({
+  deleteCookie: vi.fn(),
+}));
+
+const { deleteCookie } = require('../helpers/cookie/deleteCookie.helper');
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+});
+
+describe('useUserStore', () => {
+  it('login sets user info', () => {
+    const store = useUserStore();
+    store.login({ fullName: 'John Doe', email: 'john@example.com' });
+    expect(store.isConnected).toBe(true);
+    expect(store.fullName).toBe('John Doe');
+    expect(store.email).toBe('john@example.com');
+  });
+
+  it('disconnect resets state and clears cookies', () => {
+    const store = useUserStore();
+    store.login({ fullName: 'John Doe', email: 'john@example.com' });
+    store.disconnect();
+    expect(store.isConnected).toBe(false);
+    expect(store.fullName).toBe('');
+    expect(store.email).toBe('');
+    expect(deleteCookie.deleteCookie).toHaveBeenCalledTimes(3);
+  });
+
+  it('updateEmail updates the email', () => {
+    const store = useUserStore();
+    store.login({ fullName: 'John Doe', email: 'john@example.com' });
+    store.updateEmail('new@example.com');
+    expect(store.email).toBe('new@example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for helper utilities
- add tests for cookie helpers and auth header
- add tests for fetcher helper
- add tests for user store actions

## Testing
- `pnpm unit-test-once` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842970a212c832880ed544496f4dd73