### PR TITLE
Add simple language switcher

### DIFF
--- a/src/enums/language.enum.ts
+++ b/src/enums/language.enum.ts
@@ -1,0 +1,4 @@
+export enum LanguageEnum {
+  FR = 'fr',
+  EN = 'en',
+}

--- a/src/stores/language.ts
+++ b/src/stores/language.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia';
+
+import { LanguageEnum } from '../enums/language.enum';
+
+const headerTranslations = {
+  [LanguageEnum.FR]: {
+    home: 'Accueil',
+    login: 'Connexion',
+    register: 'Inscription',
+    logout: 'Déconnexion',
+  },
+  [LanguageEnum.EN]: {
+    home: 'Home',
+    login: 'Login',
+    register: 'Register',
+    logout: 'Logout',
+  },
+};
+
+type HeaderTranslationKey = keyof typeof headerTranslations[LanguageEnum.FR];
+
+export const useLanguageStore = defineStore('language', {
+  state: () => ({
+    current: LanguageEnum.FR as LanguageEnum,
+  }),
+  actions: {
+    setLanguage(lang: LanguageEnum) {
+      this.current = lang;
+    },
+  },
+  getters: {
+    t: (state) => (key: HeaderTranslationKey) =>
+      headerTranslations[state.current][key],
+  },
+});
+export type { HeaderTranslationKey };

--- a/src/views/components/AppHeader.vue
+++ b/src/views/components/AppHeader.vue
@@ -2,12 +2,15 @@
 import { ref } from "vue";
 
 import { useUserStore } from "../../stores/user";
+import { useLanguageStore } from "../../stores/language";
 import LoginModal from "./LoginModal.vue";
 import RegisterModal from "./RegisterModal.vue";
+import LangSwitcher from "./LangSwitcher.vue";
 
 const showLoginModal = ref(false);
 const showRegisterModal = ref(false);
 const userStore = useUserStore();
+const languageStore = useLanguageStore();
 </script>
 
 <template>
@@ -21,7 +24,7 @@ const userStore = useUserStore();
       to="/"
       class="text-l mx-2"
     >
-      Accueil
+      {{ languageStore.t('home') }}
     </router-link>
     <div class="flex-1" />
     <template v-if="!userStore.isConnected">
@@ -29,13 +32,13 @@ const userStore = useUserStore();
         class="mr-2 text-blue-600 hover:underline"
         @click="showLoginModal = true"
       >
-        Connexion
+        {{ languageStore.t('login') }}
       </button>
       <button
         class="bg-blue-600 text-white px-2 py-1 rounded"
         @click="showRegisterModal = true"
       >
-        Inscription
+        {{ languageStore.t('register') }}
       </button>
     </template>
     <template v-else>
@@ -49,9 +52,10 @@ const userStore = useUserStore();
         class="bg-red-600 text-white px-2 py-1 rounded"
         @click="userStore.disconnect"
       >
-        Déconnexion
+        {{ languageStore.t('logout') }}
       </button>
     </template>
+    <LangSwitcher class="ml-2" />
   </header>
 
   <LoginModal

--- a/src/views/components/LangSwitcher.vue
+++ b/src/views/components/LangSwitcher.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { LanguageEnum } from "../../enums/language.enum";
+import { useLanguageStore } from "../../stores/language";
+
+const languageStore = useLanguageStore();
+
+function handleChange(event: Event) {
+  const value = (event.target as HTMLSelectElement).value as LanguageEnum;
+  languageStore.setLanguage(value);
+}
+</script>
+
+<template>
+  <select
+    :value="languageStore.current"
+    @change="handleChange"
+    class="border border-gray-400 rounded px-2 py-1 text-sm"
+  >
+    <option :value="LanguageEnum.FR">FR</option>
+    <option :value="LanguageEnum.EN">EN</option>
+  </select>
+</template>


### PR DESCRIPTION
## Summary
- implement a tiny translation store with English and French values
- create a language selector component
- wire the header buttons to use this translation system

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config)*
- `pnpm run unit-test-once` *(fails: vitest not found)*
- `pnpm run check-types` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429c59f4a48328b699e70c2c81f48f