### PR TITLE
Add cart with local storage

### DIFF
--- a/src/assets/translations.ts
+++ b/src/assets/translations.ts
@@ -30,6 +30,9 @@ export const translations = {
     productDescription: "Voici un super produit.",
     searchPlaceholder: "Rechercher un produit",
     allCategories: "Toutes les catégories",
+    addToCart: "Ajouter au panier",
+    cart: "Panier",
+    cartEmpty: "Votre panier est vide",
   },
   [LanguageEnum.EN]: {
     home: "Home",
@@ -60,5 +63,8 @@ export const translations = {
     productDescription: "Here is an awesome product.",
     searchPlaceholder: "Search a product",
     allCategories: "All categories",
+    addToCart: "Add to cart",
+    cart: "Cart",
+    cartEmpty: "Your cart is empty",
   },
 };

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -1,0 +1,64 @@
+import { defineStore } from "pinia";
+
+export interface CartItem {
+  id: number;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+const STORAGE_KEY = "cartItems";
+
+function loadFromStorage(): CartItem[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as CartItem[];
+  } catch {
+    return [];
+  }
+}
+
+function saveToStorage(items: CartItem[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+export const useCartStore = defineStore("cart", {
+  state: () => ({
+    items: loadFromStorage() as CartItem[],
+  }),
+  actions: {
+    addItem(item: Omit<CartItem, "quantity">) {
+      const existing = this.items.find((i) => i.id === item.id);
+      if (existing) {
+        existing.quantity += 1;
+      } else {
+        this.items.push({ ...item, quantity: 1 });
+      }
+      saveToStorage(this.items);
+    },
+    updateQuantity(id: number, quantity: number) {
+      const product = this.items.find((i) => i.id === id);
+      if (product) {
+        product.quantity = quantity;
+        if (product.quantity <= 0) {
+          this.items = this.items.filter((i) => i.id !== id);
+        }
+        saveToStorage(this.items);
+      }
+    },
+    removeItem(id: number) {
+      this.items = this.items.filter((i) => i.id !== id);
+      saveToStorage(this.items);
+    },
+    clear() {
+      this.items = [];
+      saveToStorage(this.items);
+    },
+  },
+  getters: {
+    totalCount(state) {
+      return state.items.reduce((sum, item) => sum + item.quantity, 0);
+    },
+  },
+});

--- a/src/views/components/AppHeader.vue
+++ b/src/views/components/AppHeader.vue
@@ -3,14 +3,18 @@ import { ref } from "vue";
 
 import { useLanguageStore } from "../../stores/language";
 import { useUserStore } from "../../stores/user";
+import { useCartStore } from "../../stores/cart";
 import LangSwitcher from "./LangSwitcher.vue";
 import LoginModal from "./LoginModal.vue";
 import RegisterModal from "./RegisterModal.vue";
+import CartDropdown from "./CartDropdown.vue";
 
 const showLoginModal = ref(false);
 const showRegisterModal = ref(false);
+const showCart = ref(false);
 const userStore = useUserStore();
 const languageStore = useLanguageStore();
+const cartStore = useCartStore();
 </script>
 
 <template>
@@ -27,6 +31,15 @@ const languageStore = useLanguageStore();
       {{ languageStore.t("home") }}
     </router-link>
     <div class="flex-1" />
+    <div class="relative mr-2">
+      <button
+        class="px-2 py-1 border rounded"
+        @click="showCart = !showCart"
+      >
+        🛒 ({{ cartStore.totalCount }})
+      </button>
+      <CartDropdown v-if="showCart" class="absolute right-0" />
+    </div>
     <template v-if="!userStore.isConnected">
       <button
         class="mr-2 text-blue-600 hover:underline"

--- a/src/views/components/CartDropdown.vue
+++ b/src/views/components/CartDropdown.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useCartStore } from "../../stores/cart";
+import { useLanguageStore } from "../../stores/language";
+
+const cartStore = useCartStore();
+const languageStore = useLanguageStore();
+</script>
+
+<template>
+  <div class="mt-2 w-72 bg-white border rounded shadow p-2">
+    <p v-if="cartStore.items.length === 0" class="p-2 text-sm text-center">
+      {{ languageStore.t('cartEmpty') }}
+    </p>
+    <div v-else>
+      <div
+        v-for="item in cartStore.items"
+        :key="item.id"
+        class="flex items-center justify-between mb-2"
+      >
+        <div>
+          <p class="font-semibold">{{ item.name }}</p>
+          <p class="text-sm">{{ item.price.toFixed(2) }} €</p>
+        </div>
+        <input
+          type="number"
+          class="w-16 border p-1 rounded mr-1"
+          :value="item.quantity"
+          min="1"
+          @change="
+            cartStore.updateQuantity(
+              item.id,
+              parseInt(($event.target as HTMLInputElement).value, 10)
+            )
+          "
+        />
+        <button
+          class="text-red-600"
+          @click="cartStore.removeItem(item.id)"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/pages/homepage/Homepage.vue
+++ b/src/views/pages/homepage/Homepage.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from "vue";
 
 import { useLanguageStore } from "../../../stores/language";
+import { useCartStore } from "../../../stores/cart";
 import AppHeader from "../../components/AppHeader.vue";
 
 type Product = {
@@ -14,6 +15,7 @@ type Product = {
 };
 
 const languageStore = useLanguageStore();
+const cartStore = useCartStore();
 
 const products = ref<Product[]>([
   {
@@ -128,6 +130,12 @@ const filteredProducts = computed(() =>
           <h3 class="font-bold mb-1">{{ product.name }}</h3>
           <p class="text-sm mb-1">{{ product.description }}</p>
           <p class="font-semibold">{{ product.price.toFixed(2) }} €</p>
+          <button
+            class="mt-2 px-2 py-1 bg-blue-600 text-white rounded"
+            @click="cartStore.addItem({ id: product.id, name: product.name, price: product.price })"
+          >
+            {{ languageStore.t('addToCart') }}
+          </button>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- implement Pinia cart store with localStorage persistence
- show cart dropdown from header
- add button to add products to cart
- supply cart-related translations

## Testing
- `pnpm lint-fix` *(fails: ESLint couldn't find config)*
- `pnpm unit-test-once` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a7afa42083289b698a46cf08c169