### PR TITLE
Add cart total price

### DIFF
--- a/src/assets/translations.ts
+++ b/src/assets/translations.ts
@@ -33,6 +33,7 @@ export const translations = {
     addToCart: "Ajouter au panier",
     cart: "Panier",
     cartEmpty: "Votre panier est vide",
+    cartTotal: "Total",
   },
   [LanguageEnum.EN]: {
     home: "Home",
@@ -66,5 +67,6 @@ export const translations = {
     addToCart: "Add to cart",
     cart: "Cart",
     cartEmpty: "Your cart is empty",
+    cartTotal: "Total",
   },
 };

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -60,5 +60,8 @@ export const useCartStore = defineStore("cart", {
     totalCount(state) {
       return state.items.reduce((sum, item) => sum + item.quantity, 0);
     },
+    totalPrice(state) {
+      return state.items.reduce((sum, item) => sum + item.quantity * item.price, 0);
+    },
   },
 });

--- a/src/views/components/CartDropdown.vue
+++ b/src/views/components/CartDropdown.vue
@@ -43,6 +43,10 @@ const languageStore = useLanguageStore();
           ×
         </button>
       </div>
+      <p class="text-right font-semibold mt-2">
+        {{ languageStore.t("cartTotal") }}:
+        {{ cartStore.totalPrice.toFixed(2) }} €
+      </p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show total price in the cart dropdown
- compute total price in the cart store
- add `cartTotal` translation key for FR/EN

## Testing
- `pnpm global-test` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ae1d34948328b8dee4da90984ec3